### PR TITLE
Added zsh_history and Updated README

### DIFF
--- a/DFLinux.sh
+++ b/DFLinux.sh
@@ -53,11 +53,19 @@ write_output "ls -lah /var/log/" "var_log_directory_listing.txt"
 
 for user_home in /home/*; do
     username=$(basename "$user_home")
+    
     if [ -f "$user_home/.bash_history" ]; then
         write_output "cat $user_home/.bash_history" "bash_command_history_$username.txt"
     else
         echo "No .bash_history for $username" >> "$output_dir/bash_command_history_$username.txt"
     fi
+    
+    if [ -f "$user_home/.zsh_history" ]; then
+        write_output "cat $user_home/.zsh_history" "zsh_command_history_$username.txt"
+    else
+        echo "No .zsh_history for $username" >> "$output_dir/zsh_command_history_$username.txt"
+    fi
+    
     write_output "cat $user_home/.local/share/recently-used.xbel" "recently_used_files_$username.txt"
 done
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains an advanced Bash script designed for conducting digital
 - **Installed Programs**: Lists all installed packages using both `rpm` and `apt`.
 - **Hardware Information**: Retrieves detailed information about PCI devices, hardware summaries, and BIOS data.
 - **System Logs**: Captures system journal logs and the contents of the `/var/log` directory.
-- **User Data**: Extracts user-specific data like recently used files and bash command history.
+- **User Data**: Extracts user-specific data like recently used files and bash command history and zsh command history.
 - **Memory Dump**: Performs a memory dump for detailed analysis.
 - **Process Information**: Captures information about current running processes.
 - **User Login History**: Records user login history and scheduled tasks.


### PR DESCRIPTION
Along with BASH, ZSH is commonly used as well, so let's not miss that out. Changes to the script have been tested on Kali and Mac and it works fine. 

![image](https://github.com/vm32/Digital-Forensics-Script-for-Linux/assets/16836050/e4cb4ae1-bcef-43de-a7a2-2701be9238fd)

Thanks. 