### PR TITLE
tar command update

### DIFF
--- a/DFLinux.sh
+++ b/DFLinux.sh
@@ -75,7 +75,7 @@ else
     echo "No crontab for root" >> "$output_dir/scheduled_cron_jobs_root.txt"
 fi
 
-tar -czf "$output_dir/user_data.tar.gz" $output_dir/*.txt --remove-files
+$(cd $output_dir && tar -czf $output_dir/user_data.tar.gz *.txt --remove-files)
 
 echo "Data extraction complete. Check the $output_dir directory for output." >> "$logfile"
 echo "Forensic data extraction completed at $(date)" >> "$logfile"

--- a/DFLinux.sh
+++ b/DFLinux.sh
@@ -75,7 +75,7 @@ else
     echo "No crontab for root" >> "$output_dir/scheduled_cron_jobs_root.txt"
 fi
 
-tar -czf "$output_dir/user_data.tar.gz" -C "$output_dir" ./*.txt --remove-files
+tar -czf "$output_dir/user_data.tar.gz" $output_dir/*.txt --remove-files
 
 echo "Data extraction complete. Check the $output_dir directory for output." >> "$logfile"
 echo "Forensic data extraction completed at $(date)" >> "$logfile"


### PR DESCRIPTION
Tar command used is not able to create tar file due to *.txt error shown below.

![image](https://github.com/vm32/Digital-Forensics-Script-for-Linux/assets/56958135/b58a5565-7d7a-40dc-ae4f-efcdd1b3782a)

The results directory structure is shown below where we can see the tar is not created properly and only has 45B and all the txt files are present.

![image](https://github.com/vm32/Digital-Forensics-Script-for-Linux/assets/56958135/91cc751c-fe4e-42f9-af11-e2db284f8a93)

After updating tar command this is the output of the script.

![image](https://github.com/vm32/Digital-Forensics-Script-for-Linux/assets/56958135/3e9d828e-1258-4db3-8dcc-43979e88b64b)


And this the the result desired shown below.

![image](https://github.com/vm32/Digital-Forensics-Script-for-Linux/assets/56958135/ac6226b9-4582-4147-b6e3-e2446e1f0f86)
